### PR TITLE
refactor: remove redundant outer conditional in Protectify Cart block

### DIFF
--- a/shopify/extensions/cart-extensions/blocks/protectify-cart.liquid
+++ b/shopify/extensions/cart-extensions/blocks/protectify-cart.liquid
@@ -1,4 +1,3 @@
-{% app.metafields.conditional.cart_enable %}
 {% if request.page_type == "cart" and app.metafields.conditional.cart_enable %}
   <script src="{{ 'protectify.js' | asset_url }}" defer></script>
   <link  rel="stylesheet" href="{{ 'protectify.css' | asset_url }}"  type="text/css">


### PR DESCRIPTION
- Simplified code by eliminating unnecessary wrapping conditional for `cart_enable` metafield.
- Ensures cleaner and more maintainable logic within the Liquid template.